### PR TITLE
Add `StreamExt::switch` to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Currently provided functionality:
 - `StreamExt::dedup` for deduplicating consecutive equal items
 - `StreamExt::dedup_by_key` for deduplicating consecutive items with an equal property
 - `StreamExt::batch_with` for flexible batching of the stream's items
+- `StreamExt::switch` for switching a stream of streams


### PR DESCRIPTION
This patch is adding `StreamExt::switch` to the `README.md` file.