### PR TITLE
fix: `Switch` must never poll outer stream once closed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,25 +250,15 @@ pin_project! {
     pub struct Switch<S: Stream> {
         #[pin]
         outer_stream: S,
+        outer_stream_is_closed: bool,
         #[pin]
-        state: SwitchState<S::Item>,
-    }
-}
-
-pin_project! {
-    #[project = SwitchStateProj]
-    enum SwitchState<S> {
-        None,
-        Some {
-            #[pin]
-            inner_stream: S,
-        }
+        state: Option<S::Item>,
     }
 }
 
 impl<S: Stream> Switch<S> {
     fn new(outer_stream: S) -> Self {
-        Self { outer_stream, state: SwitchState::None }
+        Self { outer_stream, outer_stream_is_closed: false, state: None }
     }
 }
 
@@ -282,34 +272,35 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
-        let mut outer_stream_closed = false;
-        while let Poll::Ready(ready) = this.outer_stream.as_mut().poll_next(cx) {
-            match ready {
-                Some(inner_stream) => {
-                    this.state.set(SwitchState::Some { inner_stream });
-                }
-                None => {
-                    outer_stream_closed = true;
-                    break;
+        if !*this.outer_stream_is_closed {
+            while let Poll::Ready(ready) = this.outer_stream.as_mut().poll_next(cx) {
+                match ready {
+                    Some(inner_stream) => {
+                        this.state.set(Some(inner_stream));
+                    }
+                    None => {
+                        *this.outer_stream_is_closed = true;
+                        break;
+                    }
                 }
             }
         }
 
-        match this.state.project() {
+        match this.state.as_mut().as_pin_mut() {
             // No inner stream has been produced yet.
-            SwitchStateProj::None => {
-                if outer_stream_closed {
+            None => {
+                if *this.outer_stream_is_closed {
                     Poll::Ready(None)
                 } else {
                     Poll::Pending
                 }
             }
             // An inner stream exists => poll it.
-            SwitchStateProj::Some { inner_stream } => match inner_stream.poll_next(cx) {
+            Some(inner_stream) => match inner_stream.poll_next(cx) {
                 // Inner stream produced an item.
                 Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
                 // Both inner and outer stream are closed.
-                Poll::Ready(None) if outer_stream_closed => Poll::Ready(None),
+                Poll::Ready(None) if *this.outer_stream_is_closed => Poll::Ready(None),
                 // Only inner stream is closed, or inner stream is pending.
                 Poll::Ready(None) | Poll::Pending => Poll::Pending,
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ extern crate alloc;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-use futures_core::Stream;
+use futures_core::{FusedStream, Stream};
 use pin_project_lite::pin_project;
 
 /// Extensions to the [`Stream`] trait.
@@ -98,6 +98,7 @@ pub trait StreamExt: Stream + Sized {
     /// [`switchAll`](https://rxjs.dev/api/index/function/switchAll).
     fn switch(self) -> Switch<Self>
     where
+        Self: FusedStream,
         Self::Item: Stream,
     {
         Switch::new(self)
@@ -250,21 +251,23 @@ pin_project! {
     pub struct Switch<S: Stream> {
         #[pin]
         outer_stream: S,
-        outer_stream_is_closed: bool,
         #[pin]
         state: Option<S::Item>,
     }
 }
 
-impl<S: Stream> Switch<S> {
+impl<S> Switch<S>
+where
+    S: FusedStream,
+{
     fn new(outer_stream: S) -> Self {
-        Self { outer_stream, outer_stream_is_closed: false, state: None }
+        Self { outer_stream, state: None }
     }
 }
 
 impl<S> Stream for Switch<S>
 where
-    S: Stream,
+    S: FusedStream,
     S::Item: Stream,
 {
     type Item = <S::Item as Stream>::Item;
@@ -272,14 +275,16 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
-        if !*this.outer_stream_is_closed {
+        let mut outer_stream_is_closed = this.outer_stream.is_terminated();
+
+        if !outer_stream_is_closed {
             while let Poll::Ready(ready) = this.outer_stream.as_mut().poll_next(cx) {
                 match ready {
                     Some(inner_stream) => {
                         this.state.set(Some(inner_stream));
                     }
                     None => {
-                        *this.outer_stream_is_closed = true;
+                        outer_stream_is_closed = true;
                         break;
                     }
                 }
@@ -289,7 +294,7 @@ where
         match this.state.as_mut().as_pin_mut() {
             // No inner stream has been produced yet.
             None => {
-                if *this.outer_stream_is_closed {
+                if outer_stream_is_closed {
                     Poll::Ready(None)
                 } else {
                     Poll::Pending
@@ -300,7 +305,7 @@ where
                 // Inner stream produced an item.
                 Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
                 // Both inner and outer stream are closed.
-                Poll::Ready(None) if *this.outer_stream_is_closed => Poll::Ready(None),
+                Poll::Ready(None) if outer_stream_is_closed => Poll::Ready(None),
                 // Only inner stream is closed, or inner stream is pending.
                 Poll::Ready(None) | Poll::Pending => Poll::Pending,
             },

--- a/tests/it/switch.rs
+++ b/tests/it/switch.rs
@@ -1,7 +1,7 @@
 use std::{pin::pin, task::Poll};
 
 use async_rx::StreamExt as _;
-use futures_util::{future::Either, stream};
+use futures_util::{future::Either, stream, StreamExt as _};
 use stream_assert::{assert_closed, assert_next_eq, assert_pending};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -14,7 +14,8 @@ fn switch_empty() {
 
 #[test]
 fn switch_eagerly_polls_outer_stream() {
-    let mut stream = stream::iter([stream::iter([1, 2, 3]), stream::iter([4, 5, 6])]).switch();
+    let mut stream =
+        stream::iter([stream::iter([1, 2, 3]), stream::iter([4, 5, 6])]).fuse().switch();
     assert_next_eq!(stream, 4);
     assert_next_eq!(stream, 5);
     assert_next_eq!(stream, 6);
@@ -23,13 +24,14 @@ fn switch_eagerly_polls_outer_stream() {
 
 #[test]
 fn switch_outer_stream_is_closed_then_stream_is_closed() {
-    let mut stream = stream::poll_fn(|_| Poll::Ready(None::<stream::Empty<()>>)).switch();
+    let mut stream = stream::poll_fn(|_| Poll::Ready(None::<stream::Empty<()>>)).fuse().switch();
     assert_closed!(stream);
 }
 
 #[test]
 fn switch_outer_stream_is_pending_then_stream_is_pending() {
-    let mut stream = stream::poll_fn(|_| Poll::<Option<stream::Empty<()>>>::Pending).switch();
+    let mut stream =
+        stream::poll_fn(|_| Poll::<Option<stream::Empty<()>>>::Pending).fuse().switch();
     assert_pending!(stream);
 }
 
@@ -55,6 +57,7 @@ fn switch_inner_stream_is_closed_then_stream_is_pending() {
                 Poll::Ready(Some(stream::poll_fn(|_| Poll::Ready(None::<()>))))
             }
         })
+        .fuse()
         .switch()
     };
     assert_pending!(stream);
@@ -74,6 +77,7 @@ fn switch_inner_stream_is_pending_then_stream_is_pending() {
                 Poll::Ready(Some(stream::pending::<()>()))
             }
         })
+        .fuse()
         .switch()
     };
     assert_pending!(stream);
@@ -83,7 +87,7 @@ fn switch_inner_stream_is_pending_then_stream_is_pending() {
 fn switch_on_channel() {
     let (tx, rx) = mpsc::unbounded_channel();
 
-    let mut stream = UnboundedReceiverStream::new(rx).switch();
+    let mut stream = UnboundedReceiverStream::new(rx).fuse().switch();
     assert_pending!(stream);
 
     tx.send(Either::Left(stream::iter(vec![1]))).unwrap();

--- a/tests/it/switch.rs
+++ b/tests/it/switch.rs
@@ -1,43 +1,82 @@
-use std::{pin::pin, slice};
+use std::{pin::pin, task::Poll};
 
 use async_rx::StreamExt as _;
-use futures_util::{
-    future::Either,
-    stream::{self, empty},
-};
+use futures_util::{future::Either, stream};
 use stream_assert::{assert_closed, assert_next_eq, assert_pending};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 #[test]
-fn empty_switch() {
-    let empty: stream::Empty<stream::Iter<slice::Iter<u8>>> = empty();
-    let mut empty_switch = empty.switch();
-    assert_closed!(empty_switch);
-}
-
-#[test]
-fn switch_single_outer_stream() {
-    let mut stream = pin!(stream::once(async { stream::iter([1, 2, 3]) }).switch());
-    assert_next_eq!(stream, 1);
-    assert_next_eq!(stream, 2);
-    assert_next_eq!(stream, 3);
+fn switch_empty() {
+    let mut stream = stream::empty::<stream::Empty<stream::Empty<()>>>().switch();
     assert_closed!(stream);
 }
 
 #[test]
-fn switch_immediately() {
-    let mut stream = pin!(stream::iter([
-        stream::iter([1, 2, 3]),
-        stream::iter([4, 5, 6]),
-        stream::iter([7, 8, 9]),
-    ])
-    .switch());
-
-    assert_next_eq!(stream, 7);
-    assert_next_eq!(stream, 8);
-    assert_next_eq!(stream, 9);
+fn switch_eagerly_polls_outer_stream() {
+    let mut stream = stream::iter([stream::iter([1, 2, 3]), stream::iter([4, 5, 6])]).switch();
+    assert_next_eq!(stream, 4);
+    assert_next_eq!(stream, 5);
+    assert_next_eq!(stream, 6);
     assert_closed!(stream);
+}
+
+#[test]
+fn switch_outer_stream_is_closed_then_stream_is_closed() {
+    let mut stream = stream::poll_fn(|_| Poll::Ready(None::<stream::Empty<()>>)).switch();
+    assert_closed!(stream);
+}
+
+#[test]
+fn switch_outer_stream_is_pending_then_stream_is_pending() {
+    let mut stream = stream::poll_fn(|_| Poll::<Option<stream::Empty<()>>>::Pending).switch();
+    assert_pending!(stream);
+}
+
+#[test]
+fn switch_outer_stream_is_closed_after_first_poll_and_inner_stream_is_closed_then_stream_is_closed()
+{
+    let mut stream =
+        pin!(stream::once(async { stream::poll_fn(|_| Poll::Ready(None::<()>)) }).switch());
+    assert_closed!(stream);
+}
+
+#[test]
+fn switch_inner_stream_is_closed_then_stream_is_pending() {
+    let mut stream = {
+        let mut yielded_once = false;
+
+        stream::poll_fn(move |_| {
+            if yielded_once {
+                Poll::Pending
+            } else {
+                yielded_once = true;
+
+                Poll::Ready(Some(stream::poll_fn(|_| Poll::Ready(None::<()>))))
+            }
+        })
+        .switch()
+    };
+    assert_pending!(stream);
+}
+
+#[test]
+fn switch_inner_stream_is_pending_then_stream_is_pending() {
+    let mut stream = {
+        let mut yielded_once = false;
+
+        stream::poll_fn(move |_| {
+            if yielded_once {
+                Poll::Pending
+            } else {
+                yielded_once = true;
+
+                Poll::Ready(Some(stream::pending::<()>()))
+            }
+        })
+        .switch()
+    };
+    assert_pending!(stream);
 }
 
 #[test]


### PR DESCRIPTION
This patch fixes `Switch` to never polls the outer stream once closed, otherwise it can panic.

This patch also improves the test suite to target one behaviour at a time.